### PR TITLE
Pin all dependencies and add supply chain security checks

### DIFF
--- a/.github/workflows/build_libtestoptimization.yml
+++ b/.github/workflows/build_libtestoptimization.yml
@@ -16,13 +16,13 @@ jobs:
     name: macOS
     runs-on: macos-14
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
             go-version: '1.24'
       - run: brew install coreutils
       - name: Checkout external repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: "DataDog/dd-trace-go"
           ref: ${{ env.dd_trace_go_ref }}
@@ -71,7 +71,7 @@ jobs:
             rm -r ./output/ios-libtestoptimization-static
         working-directory: external/internal/civisibility/native
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: mac-artifact
           path: external/internal/civisibility/native/output/*.zip*
@@ -80,13 +80,13 @@ jobs:
     name: linux-arm64
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       - name: Checkout external repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: "DataDog/dd-trace-go"
           ref: ${{ env.dd_trace_go_ref }}
@@ -106,7 +106,7 @@ jobs:
             docker run --rm -v ./output:/libtestoptimization libtestoptimization-builder:arm64
         working-directory: external/internal/civisibility/native
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: linux-arm64-artifact
           path: external/internal/civisibility/native/output/*.zip*
@@ -115,9 +115,9 @@ jobs:
     name: linux-amd64
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Checkout external repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: "DataDog/dd-trace-go"
           ref: ${{ env.dd_trace_go_ref }}
@@ -142,7 +142,7 @@ jobs:
             docker run --rm -v ./output:/libtestoptimization libtestoptimization-builder:androidarm64
         working-directory: external/internal/civisibility/native
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: linux-amd64-artifact
           path: external/internal/civisibility/native/output/*.zip*
@@ -151,9 +151,9 @@ jobs:
     name: windows
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Checkout external repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: "DataDog/dd-trace-go"
           ref: ${{ env.dd_trace_go_ref }}
@@ -169,8 +169,15 @@ jobs:
         shell: pwsh
         run: |
           $url = "https://github.com/brechtsanders/winlibs_mingw/releases/download/14.2.0posix-12.0.0-ucrt-r3/winlibs-x86_64-posix-seh-gcc-14.2.0-llvm-19.1.7-mingw-w64ucrt-12.0.0-r3.zip"
+          $expectedHash = "982be78644b2fe40187e11b209333d58d3cf17be87d87be62a7bc24f18040594"
           $output = "$env:RUNNER_TEMP\mingw.zip"
           Invoke-WebRequest -Uri $url -OutFile $output
+          $actualHash = (Get-FileHash -Path $output -Algorithm SHA256).Hash.ToLower()
+          if ($actualHash -ne $expectedHash) {
+            Write-Error "SHA256 mismatch for MinGW toolchain! Expected: $expectedHash, Got: $actualHash"
+            exit 1
+          }
+          Write-Host "MinGW checksum verified: $actualHash"
       - name: Extract MinGW toolchain
         shell: pwsh
         run: |
@@ -183,10 +190,17 @@ jobs:
         run: |
           $version = "5.0.0"
           $url = "https://github.com/upx/upx/releases/download/v$version/upx-$version-win64.zip"
+          $expectedHash = "1cc4ce7602f42350ea7a960718d4ca8b5c8949ab79b80e709286eff0107b04ea"
           $zipPath = "$env:RUNNER_TEMP\upx.zip"
           $extractPath = "$env:RUNNER_TEMP\upx"
 
           Invoke-WebRequest -Uri $url -OutFile $zipPath -UseBasicParsing
+          $actualHash = (Get-FileHash -Path $zipPath -Algorithm SHA256).Hash.ToLower()
+          if ($actualHash -ne $expectedHash) {
+            Write-Error "SHA256 mismatch for UPX! Expected: $expectedHash, Got: $actualHash"
+            exit 1
+          }
+          Write-Host "UPX checksum verified: $actualHash"
           Expand-Archive -Path $zipPath -DestinationPath $extractPath -Force
 
           $upxExe = Join-Path $extractPath "upx-$version-win64\upx.exe"
@@ -259,7 +273,7 @@ jobs:
           Remove-Item -Recurse -Force ./output/windows-x64-libtestoptimization-dynamic
         working-directory: external/internal/civisibility/native
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: windows-artifact
           path: external/internal/civisibility/native/output/*.zip*
@@ -272,55 +286,55 @@ jobs:
       contents: write
       actions: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Download artifacts from mac job
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: mac-artifact
           path: artifacts
       - name: Download artifacts from linux-arm64 job
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: linux-arm64-artifact
           path: artifacts
       - name: Download artifacts from linux-amd64 job
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: linux-amd64-artifact
           path: artifacts
       - name: Download artifacts from windows job
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: windows-artifact
           path: artifacts
       - name: Upload final artifacts
         id: artifact-upload-step
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: all-artifacts
           path: artifacts/*.zip*
           if-no-files-found: error
       - name: Trigger Python SDK tests
-        uses: benc-uk/workflow-dispatch@v1
+        uses: benc-uk/workflow-dispatch@7a027648b88c2413826b6ddd6c76114894dc5ec4 # v1
         with:
           workflow: python-sdk-tests.yml
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
           inputs: '{ "artifact_id": "${{ steps.artifact-upload-step.outputs.artifact-id }}" }'
       - name: Trigger Rust SDK tests
-        uses: benc-uk/workflow-dispatch@v1
+        uses: benc-uk/workflow-dispatch@7a027648b88c2413826b6ddd6c76114894dc5ec4 # v1
         with:
           workflow: rust-sdk-tests.yml
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
           inputs: '{ "artifact_id": "${{ steps.artifact-upload-step.outputs.artifact-id }}" }'
       - name: Wait for trigger Python SDK tests start
-        uses: lewagon/wait-on-check-action@v1.3.4
+        uses: lewagon/wait-on-check-action@ccfb013c15c8afb7bf2b7c028fb74dc5a068cccc # v1.3.4
         with:
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
           check-name: 'Download Build Artifacts for Python SDK Tests'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 10
       - name: Wait for trigger Rust SDK tests start
-        uses: lewagon/wait-on-check-action@v1.3.4
+        uses: lewagon/wait-on-check-action@ccfb013c15c8afb7bf2b7c028fb74dc5a068cccc # v1.3.4
         with:
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
           check-name: 'Download Build Artifacts for Rust SDK Tests'
@@ -336,13 +350,13 @@ jobs:
       contents: write
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: all-artifacts
           path: release_artifacts
 
       - name: Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           files: release_artifacts/*.zip*
           draft: false

--- a/.github/workflows/build_libtestoptimization.yml
+++ b/.github/workflows/build_libtestoptimization.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-            go-version: '1.24'
+            go-version: '1.25'
       - run: brew install coreutils
       - name: Checkout external repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/lint-dependencies.yml
+++ b/.github/workflows/lint-dependencies.yml
@@ -1,0 +1,80 @@
+name: Lint Dependency Pinning
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '**/Dockerfile*'
+      - '**/setup.py'
+      - '**/requirements*.txt'
+      - '**/Cargo.toml'
+
+jobs:
+  check-gha-pinning:
+    name: Check GitHub Actions are pinned to SHAs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Check for unpinned GitHub Actions
+        run: |
+          UNPINNED=$(grep -rn 'uses:.*@' .github/workflows/ \
+            | grep -v '@[0-9a-f]\{40\}' \
+            | grep -v '^\s*#' \
+            || true)
+
+          if [ -n "$UNPINNED" ]; then
+            echo "::error::Found GitHub Actions not pinned to full-length commit SHAs:"
+            echo "$UNPINNED"
+            echo ""
+            echo "All actions must be pinned to a full 40-character commit SHA with a version comment."
+            echo "Example: uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4"
+            exit 1
+          fi
+
+          echo "All GitHub Actions are pinned to commit SHAs."
+
+  check-dockerfile-pinning:
+    name: Check Dockerfiles use pinned base images
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Check for unpinned Docker base images
+        run: |
+          UNPINNED=$(grep -rn '^FROM ' --include='Dockerfile*' . \
+            | grep -v '@sha256:' \
+            || true)
+
+          if [ -n "$UNPINNED" ]; then
+            echo "::error::Found Dockerfiles with unpinned base images (missing @sha256: digest):"
+            echo "$UNPINNED"
+            echo ""
+            echo "All Docker base images must be pinned with a sha256 digest."
+            echo "Example: FROM golang:1.24.1-bookworm@sha256:abc123..."
+            exit 1
+          fi
+
+          echo "All Docker base images are pinned with sha256 digests."
+
+  check-lockfiles:
+    name: Check lockfiles are present
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Check Cargo.lock exists
+        run: |
+          if [ ! -f sdks/rust/test-optimization-sdk/Cargo.lock ]; then
+            echo "::error::Cargo.lock is missing. Run 'cargo generate-lockfile' and commit the lockfile."
+            exit 1
+          fi
+          echo "Cargo.lock is present."
+
+      - name: Check Python requirements.txt exists
+        run: |
+          if [ ! -f sdks/python/test-optimization-sdk/requirements.txt ]; then
+            echo "::error::requirements.txt is missing. Pinned Python dependencies are required for CI."
+            exit 1
+          fi
+          echo "requirements.txt is present."

--- a/.github/workflows/lint-dependencies.yml
+++ b/.github/workflows/lint-dependencies.yml
@@ -19,8 +19,10 @@ jobs:
       - name: Check for unpinned GitHub Actions
         run: |
           UNPINNED=$(grep -rn 'uses:.*@' .github/workflows/ \
+            --include='*.yml' --include='*.yaml' \
             | grep -v '@[0-9a-f]\{40\}' \
             | grep -v '^\s*#' \
+            | grep -v 'grep.*uses:' \
             || true)
 
           if [ -n "$UNPINNED" ]; then

--- a/.github/workflows/python-sdk-tests.yml
+++ b/.github/workflows/python-sdk-tests.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Create Check
         id: create_check
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const checkRun = await github.rest.checks.create({ owner: context.repo.owner, repo: context.repo.repo, name: process.env.JOB_DISPLAY_NAME, head_sha: context.sha, status: "in_progress" });
@@ -44,7 +44,7 @@ jobs:
           ls -la
 
       - name: Upload artifacts for test jobs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: test-artifacts
           path: ${{ github.workspace }}/build_artifacts
@@ -52,7 +52,7 @@ jobs:
 
       - name: Update Check
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             await github.rest.checks.update({ owner: context.repo.owner, repo: context.repo.repo, check_run_id: parseInt("${{ steps.create_check.outputs.check_run_id }}"), status: "completed", conclusion: "${{ job.status }}" === "success" ? "success" : "failure" });
@@ -71,17 +71,17 @@ jobs:
     steps:
       - name: Create Check
         id: create_check
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const checkRun = await github.rest.checks.create({ owner: context.repo.owner, repo: context.repo.repo, name: process.env.JOB_DISPLAY_NAME, head_sha: context.sha, status: "in_progress" });
             core.setOutput("check_run_id", checkRun.data.id);
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Download test artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: test-artifacts
           path: ${{ github.workspace }}/build_artifacts
@@ -93,7 +93,7 @@ jobs:
 
       - name: Update Check
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             await github.rest.checks.update({ owner: context.repo.owner, repo: context.repo.repo, check_run_id: parseInt("${{ steps.create_check.outputs.check_run_id }}"), status: "completed", conclusion: "${{ job.status }}" === "success" ? "success" : "failure" });
@@ -112,38 +112,38 @@ jobs:
     steps:
       - name: Create Check
         id: create_check
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const checkRun = await github.rest.checks.create({ owner: context.repo.owner, repo: context.repo.repo, name: process.env.JOB_DISPLAY_NAME, head_sha: context.sha, status: "in_progress" });
             core.setOutput("check_run_id", checkRun.data.id);
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Download test artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: test-artifacts
           path: ${{ github.workspace }}/build_artifacts
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: '3.10'
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e .
-          pip install pytest
+          pip install -r requirements.txt
+          pip install -e . --no-deps
 
       - name: Run tests
         run: pytest --capture=no
 
       - name: Update Check
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             await github.rest.checks.update({ owner: context.repo.owner, repo: context.repo.repo, check_run_id: parseInt("${{ steps.create_check.outputs.check_run_id }}"), status: "completed", conclusion: "${{ job.status }}" === "success" ? "success" : "failure" });
@@ -162,26 +162,26 @@ jobs:
     steps:
       - name: Create Check
         id: create_check
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const checkRun = await github.rest.checks.create({ owner: context.repo.owner, repo: context.repo.repo, name: process.env.JOB_DISPLAY_NAME, head_sha: context.sha, status: "in_progress" });
             core.setOutput("check_run_id", checkRun.data.id);
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Download test artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: test-artifacts
           path: ${{ github.workspace }}/build_artifacts
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Build and run tests
         run: |
@@ -190,7 +190,7 @@ jobs:
 
       - name: Update Check
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             await github.rest.checks.update({ owner: context.repo.owner, repo: context.repo.repo, check_run_id: parseInt("${{ steps.create_check.outputs.check_run_id }}"), status: "completed", conclusion: "${{ job.status }}" === "success" ? "success" : "failure" });
@@ -209,38 +209,38 @@ jobs:
     steps:
       - name: Create Check
         id: create_check
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const checkRun = await github.rest.checks.create({ owner: context.repo.owner, repo: context.repo.repo, name: process.env.JOB_DISPLAY_NAME, head_sha: context.sha, status: "in_progress" });
             core.setOutput("check_run_id", checkRun.data.id);
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Download test artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: test-artifacts
           path: ${{ github.workspace }}/build_artifacts
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: '3.10'
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e .
-          pip install pytest
+          pip install -r requirements.txt
+          pip install -e . --no-deps
 
       - name: Run tests
         run: pytest --capture=no
 
       - name: Update Check
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             await github.rest.checks.update({ owner: context.repo.owner, repo: context.repo.repo, check_run_id: parseInt("${{ steps.create_check.outputs.check_run_id }}"), status: "completed", conclusion: "${{ job.status }}" === "success" ? "success" : "failure" });
@@ -259,38 +259,38 @@ jobs:
     steps:
       - name: Create Check
         id: create_check
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const checkRun = await github.rest.checks.create({ owner: context.repo.owner, repo: context.repo.repo, name: process.env.JOB_DISPLAY_NAME, head_sha: context.sha, status: "in_progress" });
             core.setOutput("check_run_id", checkRun.data.id);
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Download test artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: test-artifacts
           path: ${{ github.workspace }}/build_artifacts
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: '3.10'
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e .
-          pip install pytest
+          pip install -r requirements.txt
+          pip install -e . --no-deps
 
       - name: Run tests
         run: pytest --capture=no
 
       - name: Update Check
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             await github.rest.checks.update({ owner: context.repo.owner, repo: context.repo.repo, check_run_id: parseInt("${{ steps.create_check.outputs.check_run_id }}"), status: "completed", conclusion: "${{ job.status }}" === "success" ? "success" : "failure" });

--- a/.github/workflows/rust-sdk-tests.yml
+++ b/.github/workflows/rust-sdk-tests.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Create Check
         id: create_check
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const checkRun = await github.rest.checks.create({ owner: context.repo.owner, repo: context.repo.repo, name: process.env.JOB_DISPLAY_NAME, head_sha: context.sha, status: "in_progress" });
@@ -43,7 +43,7 @@ jobs:
           ls -la
 
       - name: Upload artifacts for test jobs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: test-artifacts
           path: ${{ github.workspace }}/build_artifacts
@@ -51,7 +51,7 @@ jobs:
 
       - name: Update Check
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             await github.rest.checks.update({ owner: context.repo.owner, repo: context.repo.repo, check_run_id: parseInt("${{ steps.create_check.outputs.check_run_id }}"), status: "completed", conclusion: "${{ job.status }}" === "success" ? "success" : "failure" });
@@ -71,17 +71,17 @@ jobs:
     steps:
       - name: Create Check
         id: create_check
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const checkRun = await github.rest.checks.create({ owner: context.repo.owner, repo: context.repo.repo, name: process.env.JOB_DISPLAY_NAME, head_sha: context.sha, status: "in_progress" });
             core.setOutput("check_run_id", checkRun.data.id);
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Download test artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: test-artifacts
           path: ${{ github.workspace }}/build_artifacts
@@ -93,7 +93,7 @@ jobs:
 
       - name: Update Check
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             await github.rest.checks.update({ owner: context.repo.owner, repo: context.repo.repo, check_run_id: parseInt("${{ steps.create_check.outputs.check_run_id }}"), status: "completed", conclusion: "${{ job.status }}" === "success" ? "success" : "failure" });
@@ -113,23 +113,23 @@ jobs:
     steps:
       - name: Create Check
         id: create_check
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const checkRun = await github.rest.checks.create({ owner: context.repo.owner, repo: context.repo.repo, name: process.env.JOB_DISPLAY_NAME, head_sha: context.sha, status: "in_progress" });
             core.setOutput("check_run_id", checkRun.data.id);
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Download test artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: test-artifacts
           path: ${{ github.workspace }}/build_artifacts
 
       - name: Install rust nightly
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1
         with:
             toolchain: nightly
             override: true
@@ -140,7 +140,7 @@ jobs:
 
       - name: Update Check
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             await github.rest.checks.update({ owner: context.repo.owner, repo: context.repo.repo, check_run_id: parseInt("${{ steps.create_check.outputs.check_run_id }}"), status: "completed", conclusion: "${{ job.status }}" === "success" ? "success" : "failure" });
@@ -160,26 +160,26 @@ jobs:
     steps:
       - name: Create Check
         id: create_check
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const checkRun = await github.rest.checks.create({ owner: context.repo.owner, repo: context.repo.repo, name: process.env.JOB_DISPLAY_NAME, head_sha: context.sha, status: "in_progress" });
             core.setOutput("check_run_id", checkRun.data.id);
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Download test artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: test-artifacts
           path: ${{ github.workspace }}/build_artifacts
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Build and run tests
         run: |
@@ -188,7 +188,7 @@ jobs:
 
       - name: Update Check
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             await github.rest.checks.update({ owner: context.repo.owner, repo: context.repo.repo, check_run_id: parseInt("${{ steps.create_check.outputs.check_run_id }}"), status: "completed", conclusion: "${{ job.status }}" === "success" ? "success" : "failure" });
@@ -208,29 +208,29 @@ jobs:
     steps:
       - name: Create Check
         id: create_check
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const checkRun = await github.rest.checks.create({ owner: context.repo.owner, repo: context.repo.repo, name: process.env.JOB_DISPLAY_NAME, head_sha: context.sha, status: "in_progress" });
             core.setOutput("check_run_id", checkRun.data.id);
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Download test artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: test-artifacts
           path: ${{ github.workspace }}/build_artifacts
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: x86_64-apple-darwin
           components: rustfmt, clippy
 
       - name: Cache dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           prefix-key: rust-cache-macos
 
@@ -239,7 +239,7 @@ jobs:
 
       - name: Update Check
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             await github.rest.checks.update({ owner: context.repo.owner, repo: context.repo.repo, check_run_id: parseInt("${{ steps.create_check.outputs.check_run_id }}"), status: "completed", conclusion: "${{ job.status }}" === "success" ? "success" : "failure" });
@@ -259,23 +259,23 @@ jobs:
     steps:
       - name: Create Check
         id: create_check
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const checkRun = await github.rest.checks.create({ owner: context.repo.owner, repo: context.repo.repo, name: process.env.JOB_DISPLAY_NAME, head_sha: context.sha, status: "in_progress" });
             core.setOutput("check_run_id", checkRun.data.id);
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Download test artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: test-artifacts
           path: ${{ github.workspace }}/build_artifacts
 
       - name: Install rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1
         with:
             override: true
 
@@ -284,7 +284,7 @@ jobs:
 
       - name: Update Check
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             await github.rest.checks.update({ owner: context.repo.owner, repo: context.repo.repo, check_run_id: parseInt("${{ steps.create_check.outputs.check_run_id }}"), status: "completed", conclusion: "${{ job.status }}" === "success" ? "success" : "failure" });

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the static library
-FROM golang:1.24.1-bookworm AS builder
+FROM golang:1.24.1-bookworm@sha256:fa1a01d362a7b9df68b021d59a124d28cae6d99ebd1a876e3557c4dd092f1b1d AS builder
 
 # Install dependencies
 RUN apt-get update && apt-get install -y gcc binutils
@@ -29,7 +29,7 @@ RUN go build -tags civisibility_native -buildmode=c-shared -ldflags="-s -w" -gcf
 RUN strip --strip-unneeded ./output/dynamic/libtestoptimization.so
 
 # Stage 2: Extract the library
-FROM alpine:latest
+FROM alpine:3.21@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
 
 # Build arguments for the final archive names; you can override these during build
 ARG FILE_NAME=libtestoptimization

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the static library
-FROM golang:1.24.1-bookworm@sha256:fa1a01d362a7b9df68b021d59a124d28cae6d99ebd1a876e3557c4dd092f1b1d AS builder
+FROM golang:1.25.8-bookworm@sha256:32aa75b183de47212568d85c4ab4a7e8a303efc06de2ab6395c47c0442acf42b AS builder
 
 # Install dependencies
 RUN apt-get update && apt-get install -y gcc binutils

--- a/build/Dockerfile-android
+++ b/build/Dockerfile-android
@@ -1,5 +1,5 @@
 # Stage 1: Build the static library
-FROM golang:1.24.1-bookworm@sha256:fa1a01d362a7b9df68b021d59a124d28cae6d99ebd1a876e3557c4dd092f1b1d AS builder
+FROM golang:1.25.8-bookworm@sha256:32aa75b183de47212568d85c4ab4a7e8a303efc06de2ab6395c47c0442acf42b AS builder
 
 # Install dependencies
 RUN apt-get update && apt search openjdk && apt-get install -y gcc musl-tools build-essential devscripts openjdk-17-jdk

--- a/build/Dockerfile-android
+++ b/build/Dockerfile-android
@@ -1,5 +1,5 @@
 # Stage 1: Build the static library
-FROM golang:1 AS builder
+FROM golang:1.24.1-bookworm@sha256:fa1a01d362a7b9df68b021d59a124d28cae6d99ebd1a876e3557c4dd092f1b1d AS builder
 
 # Install dependencies
 RUN apt-get update && apt search openjdk && apt-get install -y gcc musl-tools build-essential devscripts openjdk-17-jdk
@@ -10,6 +10,7 @@ RUN apt-get update && apt search openjdk && apt-get install -y gcc musl-tools bu
 ENV ANDROID_HOME=/root
 ENV PATH=$PATH:$ANDROID_HOME/cmdline-tools/tools:$ANDROID_HOME/cmdline-tools/tools/bin:$ANDROID_HOME/platform-tools:$ANDROID_HOME/build-tools:$ANDROID_HOME/ndk-bundle:$ANDROID_HOME/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/bin:$ANDROID_HOME/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include
 RUN curl -L https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip -o sdktools.zip && \
+    echo "2d2d50857e4eb553af5a6dc3ad507a17adf43d115264b1afc116f95c92e5e258  sdktools.zip" | sha256sum -c - && \
     unzip sdktools.zip -d /root/cmdline-tools && \
     mv /root/cmdline-tools/cmdline-tools /root/cmdline-tools/tools && \
     rm sdktools.zip
@@ -20,6 +21,7 @@ RUN mkdir ~/.android && touch ~/.android/repositories.cfg && \
 # 'ndk-bundle' is the default directory name when NDK is installed through Android Studio so reusing that naming convention
 # download URL: https://developer.android.com/ndk/downloads
 RUN curl -L https://dl.google.com/android/repository/android-ndk-r27c-linux.zip -o androidndk.zip && \
+    echo "59c2f6dc96743b5daf5d1626684640b20a6bd2b1d85b13156b90333741bad5cc  androidndk.zip" | sha256sum -c - && \
     unzip androidndk.zip -d /root && \
     rm androidndk.zip && \
     mv /root/android-ndk* /root/ndk-bundle
@@ -54,7 +56,7 @@ WORKDIR /app/internal/civisibility/native
 RUN go build -tags civisibility_native -buildmode=c-shared -o ./output/dynamic/libtestoptimization.so *.go
 
 # Stage 2: Extract the library
-FROM alpine:latest
+FROM alpine:3.21@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
 
 # Build arguments for the final archive names; you can override these during build
 ARG FILE_NAME=libcivisibility

--- a/build/Dockerfile-windows
+++ b/build/Dockerfile-windows
@@ -1,5 +1,5 @@
 # Stage 1: Prepare the library
-FROM alpine:latest
+FROM alpine:3.21@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
 
 # Build arguments for the final archive names; you can override these during build
 ARG FILE_NAME=libcivisibility

--- a/sdks/python/test-optimization-sdk/Dockerfile
+++ b/sdks/python/test-optimization-sdk/Dockerfile
@@ -1,5 +1,5 @@
 # Use the official Python image as the base
-FROM python:3.10-slim-bookworm
+FROM python:3.10-slim-bookworm@sha256:a1a9bb579ff76c1751323cbdefb416462b225868dadc657e44053c266d63091a
 
 # Set the working directory
 WORKDIR /usr/src/test-optimization-sdk
@@ -7,17 +7,17 @@ WORKDIR /usr/src/test-optimization-sdk
 # Install build dependencies
 RUN apt-get update && apt-get install -y pkg-config libssl-dev
 
-# Copy the setup files first to leverage Docker cache
-COPY setup.py ./
+# Copy the setup and requirements files first to leverage Docker cache
+COPY setup.py requirements.txt ./
 
 # Copy the source code
 COPY src ./src
 COPY tests ./tests
 
-# Install the package in development mode and install pytest
+# Install the package in development mode using pinned dependencies
 RUN pip install --upgrade pip && \
-    pip install -e . && \
-    pip install pytest
+    pip install -r requirements.txt && \
+    pip install -e . --no-deps
 
 # Run the tests
 CMD ["pytest", "--capture=no"] 

--- a/sdks/python/test-optimization-sdk/requirements.txt
+++ b/sdks/python/test-optimization-sdk/requirements.txt
@@ -1,0 +1,6 @@
+# Pinned dependencies for CI reproducibility.
+# Update these versions intentionally, not automatically.
+# Generated on 2026-04-07.
+cffi==2.0.0
+typing-extensions==4.15.0
+pytest==9.0.2

--- a/sdks/python/test-optimization-sdk/setup.py
+++ b/sdks/python/test-optimization-sdk/setup.py
@@ -14,15 +14,15 @@ setup(
     package_dir={"": "src"},
     python_requires=">=3.7",
     install_requires=[
-        "cffi>=1.15.0",
-        "typing-extensions>=4.0.0",
+        "cffi>=1.15.0,<3.0.0",
+        "typing-extensions>=4.0.0,<5.0.0",
     ],
     extras_require={
         "dev": [
-            "pytest>=7.0.0",
-            "black>=22.0.0",
-            "isort>=5.0.0",
-            "mypy>=0.900",
+            "pytest>=7.0.0,<10.0.0",
+            "black>=22.0.0,<27.0.0",
+            "isort>=5.0.0,<9.0.0",
+            "mypy>=0.900,<2.0.0",
         ],
     },
     classifiers=[

--- a/sdks/rust/test-optimization-sdk/Dockerfile
+++ b/sdks/rust/test-optimization-sdk/Dockerfile
@@ -1,5 +1,5 @@
 # Use the official Rust image as the base
-FROM rust:1.85-slim-bookworm
+FROM rust:1.85-slim-bookworm@sha256:9f841bbe9e7d8e37ceb96ed907265a3a0df7f44e3737d0b100e7907a679acb36
 
 RUN apt-get update && apt-get install -y pkg-config libssl-dev
 


### PR DESCRIPTION
## Summary
- Pin all 14 unique GitHub Actions to full-length commit SHAs (with version comments) across all 3 workflow files
- Pin all Docker base images with `@sha256:` digests; replace floating tags (`alpine:latest`, `golang:1`) with specific versions
- Bump Go from 1.24.1 to 1.25.8 to match `dd-trace-go` main's `go >= 1.25.0` requirement
- Add upper bounds to Python dependency ranges in `setup.py` and create a pinned `requirements.txt` lockfile for CI reproducibility
- Add SHA256 checksum verification for all externally downloaded binaries (MinGW, UPX, Android SDK command-line tools, Android NDK)
- Add `lint-dependencies.yml` CI workflow that validates pinning on future PRs (GHA SHAs, Docker digests, lockfile presence)

## Test plan
- [x] Verify `build_libtestoptimization.yml` runs successfully on all platforms (macOS, Linux ARM64/AMD64, Windows, Android)
- [x] Verify `python-sdk-tests.yml` runs successfully (Docker and direct install paths)
- [x] Verify `rust-sdk-tests.yml` runs successfully (Docker, Linux, macOS, Windows)
- [x] Verify `lint-dependencies.yml` passes on this PR
- [x] Verify `lint-dependencies.yml` would fail if a new unpinned action or Docker image is introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)